### PR TITLE
Remove type attribute from javascript tags

### DIFF
--- a/404.php
+++ b/404.php
@@ -10,7 +10,7 @@ get_header(); ?>
 				<p>Nope. This page doesn't exist. Sorry!</p>
       </div>
 
-	<script type="text/javascript">
+	<script>
 		// focus on search field after it has loaded
 		document.getElementById('s') && document.getElementById('s').focus();
 	</script>

--- a/footer.php
+++ b/footer.php
@@ -19,7 +19,7 @@
 
   </div> <!-- / .wrapper -->
 
-<script type="text/javascript">
+<script>
 
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-20752697-1']);
@@ -27,7 +27,7 @@
   _gaq.push(['_trackPageview']);
 
   (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    var ga = document.createElement('script'); ga.async = true;
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();

--- a/header.php
+++ b/header.php
@@ -18,8 +18,8 @@
   <script src="<?php echo get_template_directory_uri(); ?>/js/jquery.1.7.1.min.js"></script>
   <script src="<?php echo get_template_directory_uri(); ?>/js/jquery.fittext.js"></script>
   <script src="<?php echo get_template_directory_uri(); ?>/js/app.js"></script>
-  <script type="text/javascript" src="http://use.typekit.com/cjx7kil.js"></script>
-  <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+  <script src="http://use.typekit.com/cjx7kil.js"></script>
+  <script>try{Typekit.load();}catch(e){}</script>
   <script src="<?php echo get_template_directory_uri(); ?>/js/respond.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
In HTML5, it is no longer necessary to specify the type attribute of the script tag if it is javascript ([spec](https://www.w3.org/TR/html52/semantics-scripting.html#element-attrdef-script-type)). It is recommended to omit the attribute instead.